### PR TITLE
Add option to display QR Code when server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-## This Repository contains Python examples for [DroidPad](https://github.com/umer0586/DroidPad) Android app 
+## This Repository contains Python examples for [DroidPad](https://github.com/umer0586/DroidPad) Android app
 
 1. ### Clone this Repo
 ```bash
 git clone https://github.com/umer0586/droidpad-python-examples
-```  
+```
 2. ### Install requirements
 ```bash
 pip install -r requirements.txt
@@ -39,13 +39,13 @@ Create a new controller in [DroidPad](https://github.com/umer0586/DroidPad). The
 DroidPad functions as a **BLE peripheral** and sends notifications containing `CSV` strings to connected client through the characteristic UUID: `dc3f5274-33ba-48de-8246-43bf8985b323`.
 
 #### Steps to Connect:
-1. **Start the GATT Server on DroidPad**:  
+1. **Start the GATT Server on DroidPad**:
    - Open a control pad with BLE connection and tap the **Play** button to initialize the GATT server and start advertising.
 
-2. **Subscribe Using the Python Client**:  
+2. **Subscribe Using the Python Client**:
    - Navigate to the `BLEClient` directory in the DroidPad Python examples repository.
    - Run the `subscribe.py` script:
-     
+
      ```bash
      python subscribe.py
      ```
@@ -53,7 +53,7 @@ DroidPad functions as a **BLE peripheral** and sends notifications containing `C
      - Scans for nearby BLE devices advertising the service UUID: `4fbfc1d7-f509-44ab-afe1-62ea40a4b111`.
      - Subscribes to notifications from the characteristic UUID: `dc3f5274-33ba-48de-8246-43bf8985b323`.
 
-3. **View Notifications**:  
+3. **View Notifications**:
    - Once the script connects to DroidPad, it displays `CSV` strings in the console.
    - These notifications are triggered by interactions with items on the control pad.
 
@@ -62,7 +62,7 @@ DroidPad functions as a **BLE peripheral** and sends notifications containing `C
 
 ### Configurable Server (by [imsamuka](https://github.com/imsamuka))
 
-This server is configured with a [TOML](https://toml.io) file, and supports multiple TCP/UDP droidpad servers simultaneosly. Theres's a documented [default config file](configServer/default.toml) to use as a reference. There are other examples in the [configServer folder](configServer/).
+This server is configured with a [TOML](https://toml.io) file, and supports multiple TCP/UDP droidpad servers simultaneosly. Theres's a documented [default config file](configServer/default.toml) to use as a reference. There are other examples in the [configServer folder](configServer/). You can use the `--qr` flag to display a QRCode to import the pads in the app.
 
 ### Usage
 
@@ -75,7 +75,7 @@ cd configServer
 ## Running Servers
 
 ```bash
-python config-server.py [CONFIG_FILE]
+python config-server.py [--qr] [CONFIG_FILE]
 
 # Examples:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ DroidPad functions as a **BLE peripheral** and sends notifications containing `C
 
 ### Configurable Server (by [imsamuka](https://github.com/imsamuka))
 
-This server is configured with a [TOML](https://toml.io) file, and supports multiple TCP/UDP droidpad servers simultaneosly. Theres's a documented [default config file](configServer/default.toml) to use as a reference. There are other examples in the [configServer folder](configServer/). You can use the `--qr` flag to display a QRCode to import the pads in the app.
+This server is configured with a [TOML](https://toml.io) file, and supports multiple TCP/UDP droidpad servers simultaneosly. Theres's a documented [default config file](configServer/default.toml) to use as a reference. There are other examples in the [configServer folder](configServer/).
 
 ### Usage
 
@@ -83,6 +83,15 @@ python config-server.py default.toml
 
 python config-server.py linux/mouse-x11.toml
 ```
+
+### Generating QR Code
+
+You can use the `--qr` flag to display a QRCode to import the pads in the app.
+This auto generated import is intended for development use only. The server will
+also try to load a file `pad_name.json` adjacent to the `CONFIG_FILE` and use that
+as a template to generate the QR Code, preserving element positions, scaling, colors,
+and most other properties.
+
 
 ## Writing Server Configuration
 

--- a/configServer/config-server.py
+++ b/configServer/config-server.py
@@ -10,7 +10,7 @@ import subprocess
 import argparse
 import base64
 import zlib
-
+import ipaddress
 
 def qr_encode(obj: dict):
     from qrcode.main import QRCode
@@ -24,7 +24,7 @@ def qr_encode(obj: dict):
 
 def get_wlan():
     for ip in socket.gethostbyname_ex(socket.gethostname())[-1]:
-        if ip.startswith("192.168."):
+        if ipaddress.ip_address(ip).is_private:
             return ip
     return "127.0.0.1"
 

--- a/configServer/config-server.py
+++ b/configServer/config-server.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 import threading
@@ -5,6 +6,7 @@ import tomllib
 import socketserver
 import json
 import subprocess
+import argparse
 
 
 def create_servers(config):
@@ -274,14 +276,28 @@ class TCPServer(RulesMixIn, socketserver.ThreadingTCPServer):
 class UDPServer(RulesMixIn, socketserver.UDPServer):
     pass  # A thread for each UDP datagram is overkill
 
+def main():
+    parser = argparse.ArgumentParser(
+        description="Droidpad server configured with a TOML file \
+            supporting multiple TCP/UDP servers together",
+        allow_abbrev=False
+    )
+    parser.add_argument('config_file', nargs='?',
+                        default=os.path.join(sys.path[0], "default.toml"))
+    parser.add_argument("--qr", help="display QR Code on startup",
+                        dest="display_qr", action=argparse.BooleanOptionalAction)
 
-if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1]:
-        config_file = sys.argv[1]
-    else:
-        config_file = "configServer/default.toml"
+    args = parser.parse_args()
 
-    with open(config_file, "rb") as f:
+    with open(args.config_file, "rb") as f:
         config = tomllib.load(f)
 
+    if None != args.display_qr:
+        for pad_config in config.values():
+            pad_config["display_qr"] = args.display_qr
+
     create_servers(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/configServer/config-server.py
+++ b/configServer/config-server.py
@@ -23,6 +23,11 @@ def qr_encode(obj: dict):
     qr.make()
     return qr
 
+def get_wlan():
+    for ip in socket.gethostbyname_ex(socket.gethostname())[-1]:
+        if ip.startswith("192.168."):
+            return ip
+    return "127.0.0.1"
 
 def create_servers(config):
     servers = []
@@ -220,7 +225,7 @@ class RulesMixIn(socketserver.BaseServer):
                 "controlPadId": 0,
                 "connectionType": pad_config["type"],
                 "configJson": json.dumps({
-                    "host": socket.gethostbyname(socket.gethostname()),
+                    "host": get_wlan(),
                     "port": pad_config["port"]
                 })
             },

--- a/configServer/config-server.py
+++ b/configServer/config-server.py
@@ -22,7 +22,9 @@ def qr_encode(obj: dict):
     qr.make()
     return qr
 
-def get_wlan():
+def get_wlan(host: str):
+    if host != "0.0.0.0":
+        return host
     for ip in socket.gethostbyname_ex(socket.gethostname())[-1]:
         if ipaddress.ip_address(ip).is_private:
             return ip
@@ -224,7 +226,7 @@ class RulesMixIn(socketserver.BaseServer):
                 "controlPadId": 0,
                 "connectionType": pad_config["type"],
                 "configJson": json.dumps({
-                    "host": get_wlan(),
+                    "host": get_wlan(pad_config["host"]),
                     "port": pad_config["port"]
                 })
             },

--- a/configServer/config-server.py
+++ b/configServer/config-server.py
@@ -10,7 +10,6 @@ import subprocess
 import argparse
 import base64
 import zlib
-import traceback
 
 
 def qr_encode(obj: dict):
@@ -234,10 +233,7 @@ class RulesMixIn(socketserver.BaseServer):
 
         qr = qr_encode(qr_data)
         qr.print_ascii(invert=True)
-        try:
-            qr.make_image().show()
-        except Exception:
-            print(traceback.format_exc())
+        qr.make_image().show()
 
     def on_event(self, event: dict):
         rules_ids = self.event_ruleids(event)

--- a/configServer/default.json
+++ b/configServer/default.json
@@ -1,0 +1,88 @@
+{
+    "controlPad": {
+        "name": "default",
+        "orientation": "PORTRAIT",
+        "width": 1080,
+        "height": 2052
+    },
+    "controlPadItems": [
+        {
+            "itemIdentifier": "arrows",
+            "controlPadId": 5,
+            "offsetX": 8.8046875,
+            "offsetY": 54.570312,
+            "itemType": "DPAD",
+            "properties": "{\"useClickAction\": true}"
+        },
+        {
+            "itemIdentifier": "ctl_id",
+            "controlPadId": 5,
+            "offsetX": 635.0254,
+            "offsetY": 1153.5479,
+            "itemType": "BUTTON",
+            "properties": "{\"text\": \"CtlId\"}"
+        },
+        {
+            "itemIdentifier": "ctl_id",
+            "controlPadId": 5,
+            "offsetX": 573.42676,
+            "offsetY": 58.125,
+            "itemType": "DPAD"
+        },
+        {
+            "itemIdentifier": "ctl_id",
+            "controlPadId": 5,
+            "offsetX": 57.756836,
+            "offsetY": 1529.1143,
+            "itemType": "JOYSTICK"
+        },
+        {
+            "itemIdentifier": "ctl_id",
+            "controlPadId": 5,
+            "offsetX": 110.61426,
+            "offsetY": 656.0918,
+            "itemType": "SLIDER"
+        },
+        {
+            "itemIdentifier": "ctl_id",
+            "controlPadId": 5,
+            "offsetX": 822.4961,
+            "offsetY": 660.33496,
+            "itemType": "SWITCH"
+        },
+        {
+            "itemIdentifier": "radius",
+            "controlPadId": 5,
+            "offsetX": 572.5508,
+            "offsetY": 1527.1152,
+            "itemType": "JOYSTICK"
+        },
+        {
+            "itemIdentifier": "resume",
+            "controlPadId": 5,
+            "offsetX": 813.0459,
+            "offsetY": 921.9551,
+            "itemType": "SWITCH"
+        },
+        {
+            "itemIdentifier": "uptime",
+            "controlPadId": 5,
+            "offsetX": 206.16797,
+            "offsetY": 1153.5674,
+            "itemType": "BUTTON",
+            "properties": "{\"text\": \"Uptime\", \"useClickAction\": true}"
+        },
+        {
+            "itemIdentifier": "volume",
+            "controlPadId": 5,
+            "offsetX": 112.02637,
+            "offsetY": 901.00977,
+            "itemType": "SLIDER"
+        }
+    ],
+    "connectionConfig": {
+        "controlPadId": 5,
+        "connectionType": "UDP",
+        "configJson": "{\"host\": \"192.168.56.2\", \"port\": 8080}"
+    }
+}

--- a/configServer/default.toml
+++ b/configServer/default.toml
@@ -3,7 +3,7 @@ host = "0.0.0.0"
 port = 8080
 type = "UDP" # Only "TCP" or "UDP" accepted
 
-# display QR code on the terminal on start up
+# display QR code on the terminal and screen on start up
 display_qr = false
 
 # What will be executed when the event is detected

--- a/configServer/default.toml
+++ b/configServer/default.toml
@@ -3,6 +3,9 @@ host = "0.0.0.0"
 port = 8080
 type = "UDP" # Only "TCP" or "UDP" accepted
 
+# display QR code on the terminal on start up
+display_qr = false
+
 # What will be executed when the event is detected
 # "py", "sh", "bash", "cmd", "powershell", "pwsh" - pass as a script to the executable
 #     Example: 'python -c "print(42)"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bleak==0.22.3
 websockets==14.1
-qrcode==8.0
+qrcode[pil]==8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bleak==0.22.3
 websockets==14.1
+qrcode==8.0


### PR DESCRIPTION
All my pads broke when updating to v2, so I went ahead and did the work to support the qrcodes in the server while at it. 

Now doing `--qr` will generate and display a QRCode in the terminal, and in your image viewer. I intended to make it terminal-only, but after seeing how big they got, i couldn't let it be. I'm quite impressed on how incredibly inefficient QR are to transmit JSON, and that's after the compression shenanigans you did. I can only imagine the horrors trying to transmit XML like that. It would be a good idea to adopt a small binary format i guess, but I don't know how much work would it take.

Since `qrcode` is the only external dependency used in the script, i took the liberty of wrapping the import statement inside the `qr_encode` function, that way it only crashes if you actually ask for a qr code. 